### PR TITLE
HttpException no longer exists

### DIFF
--- a/code/Errors/CMError.php
+++ b/code/Errors/CMError.php
@@ -5,7 +5,7 @@
  *
  * @author Damian Mooyman
  */
-class CMError extends HttpException {
+class CMError extends Exception {
 	
 	/**
 	 * The Campaign Monitor error code


### PR DESCRIPTION
Installed the module on 3.0.5 worked fine except when a error was thrown and it looked for the class HttpException which is not in 3.0.5
Changed the class to just Exception have not done any major testing but it fixed the project I was working on.
