### PR TITLE
Feature: get sent campaigns

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and subsequently a list.
 	function updateCMSFields(FieldList $fields) {
 
 		// Load base object
-		$resources = CMResources("my api key");
+		$resources = new CMResources("my api key");
 
 		// Get clients under our account
 		$clients = $resources->Clients()->map();
@@ -91,6 +91,26 @@ Handling subscription details from a form submission
 		);
 		$subscriber = new CMSubscriber(null, $fields, $list);
 		$subscriber->Save();
+	}
+
+```
+
+
+### Get a list of sent Campaigns
+
+Get a list of all sent campaigns for a client including from name, from email, 
+reply to email, web version URL, ID, subject, name, date sent, and the total number of recipients.
+
+See the [Campaign Monitor API documentation] (https://www.campaignmonitor.com/api/clients/#sent_campaigns) 
+for more information.
+
+
+```php
+	public function Campaigns() {
+		$resources = new CMResources("my api key");
+		if($resources && $client = $resources->getClient("my client id")) {
+			return $client->Campaigns();
+		}
 	}
 
 ```

--- a/code/Objects/CMCampaign.php
+++ b/code/Objects/CMCampaign.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Represents a campaign assigned to a client within the Campaign Monitor database
+ *
+ * @author Michael Parkhill
+ */
+class CMCampaign extends LazyLoadedCMObject {
+
+	protected function populateFrom($data) {
+		$data = $this->convertToArray($data);
+		parent::populateFrom($data);
+	}
+
+	public function getClientID() {
+		return $this->ClientID;
+	}
+
+	public function setClientID($value) {
+		$this->ClientID = $value;
+	}
+
+	public function Save() {
+		user_error("Not implemented", E_USER_ERROR);
+	}
+
+	protected function loadFullDetails() {
+		$interface = new CS_REST_Clients($this->ClientID, $this->apiKey);
+		$result = $interface->get_campaign();
+		$response = $this->parseResult($result);
+		$this->populateFrom($response);
+	}
+}

--- a/code/Objects/CMClient.php
+++ b/code/Objects/CMClient.php
@@ -121,4 +121,21 @@ class CMClient extends LazyLoadedCMObject {
 	public function Save() {
 		user_error("Not implemented", E_USER_ERROR);
 	}
+
+	/**
+	 * Retrieves all campaigns for this client
+	 *
+	 * @return ArrayList[CMCampaign]
+	 */
+	public function Campaigns() {
+		$interface = new CS_REST_Clients($this->ID, $this->apiKey);
+		$result = $interface->get_campaigns();
+		$response = $this->parseResult($result);
+
+		$campaigns = new ArrayList();
+		foreach($response as $campaignData) {
+			$campaigns->push(new CMCampaign($this->apiKey, $campaignData));
+		}
+		return $campaigns;
+	}
 }

--- a/code/Objects/CMResources.php
+++ b/code/Objects/CMResources.php
@@ -51,4 +51,15 @@ class CMResources extends CMBase {
 		return $list;
 	}
 
+	/**
+	 * Retrieves a single campaign by ID
+	 *
+	 * @param string $campaignID The campaign identifier
+	 * @return CMCampaign
+	 */
+	function getCampaign($campaignID) {
+		$campaign = new CMCampaign($this->apiKey);
+		$campaign->LoadByID($campaignID);
+		return $campaign;
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "tractorcow/silverstripe-campaignmonitor",
     "description": "Simple implementation of the campaign monitor API within Silverstripe",
     "type": "silverstripe-module",
-    "keywords": ["silverstripe", "campaign monitory"],
+    "keywords": ["silverstripe", "campaign monitor"],
     "authors": [
         {
             "name": "Damian Mooyman",
@@ -15,7 +15,7 @@
     "require": {
         "silverstripe/framework": "3.*",
         "composer/installers": "*",
-		"campaignmonitor/createsend-php": "v2.5.2"
+        "campaignmonitor/createsend-php": "v2.5.2"
     },
     "extra": {
         "installer-name": "campaignmonitor"


### PR DESCRIPTION
Adds a feature to get the list of sent campaigns for a client.
See [Campaign Monitor API Docs] (https://www.campaignmonitor.com/api/clients/#sent_campaigns)

Fixes a typo in composer.json keywords, and removed some tab/space character discrepancies.

Fixes the README example code, added the missing 'new' before instantiating the CMResources class.

Adds to README with an example of the Campaigns method in CMClient.