### PR TITLE
Return CMObject after setting field value

### DIFF
--- a/src/CMObject.php
+++ b/src/CMObject.php
@@ -105,7 +105,7 @@ abstract class CMObject extends CMBase
     public function setField(string $field, mixed $value): static
     {
         $this->record[$field] = $value;
-        return $this->record[$field];
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Because the return type is static, it needs to return the object, and not the value.